### PR TITLE
[issue#12] Remove soft warning on server startup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -9,6 +9,7 @@ CORS(app)
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + os.path.join(basedir, "app.sqlite")
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
 ma = Marshmallow(app)


### PR DESCRIPTION
There was an issue with the app config in app.py of server directory. Updated configuration to disable SQLAlchemy event tracking as it used extra resources. This fixes #12 .
